### PR TITLE
Fixed yanrpkg -> yarnpkg in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ nvm use 16
 git clone https://github.com/midi2-dev/MIDI2.0Workbench.git
 cd MIDI2.0Workbench
 sudo apt-get install yarnpkg
-yanrpkg
-yanrpkg run build
-yanrpkg run start
+yarnpkg
+yarnpkg run build
+yarnpkg run start
 ```
 
 #### Issues and Updates


### PR DESCRIPTION
found a typo in the build commands for correcting Ubuntu's node 16 compatibility 
old
```
yanrpkg
yanrpkg run build
yanrpkg run start
```
->  
new
```
yarnpkg
yarnpkg run build
yarnpkg run start
```