### PR TITLE
fix: profile ids

### DIFF
--- a/libs/profiles.js
+++ b/libs/profiles.js
@@ -406,7 +406,7 @@ exports.profiles=[
 		}
 	},
 	{
-		bank:0x21
+		bank:0x20
 		,index:0x02
 		,name:'General MIDI 2 Single Channel'
 		,type:'singleChannel'
@@ -529,7 +529,7 @@ exports.profiles=[
 		]
 	},
 	{
-		bank:0x61
+		bank:0x22
 		,index:0x00
 		,name:'Rotary Speaker Effect'
 		,type:'singleChannel'


### PR DESCRIPTION
Hello!
I found the wrong values in profiles.js. It dosen't match with Spec. Could you confirm the diffs?

- GM2 Single Channel Profile Bank is 0x20
- Rotary Speaker Profile Number MSB is 0x22