### PR TITLE
Fix for Intel macOS builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+dist/*
+node_modules/*
+yarn.lock

--- a/package.json
+++ b/package.json
@@ -57,8 +57,7 @@
       "target": {
         "target": "dmg",
         "arch": [
-          "x64",
-          "arm64"
+          "universal"
         ]
       },
       "publish": "github"


### PR DESCRIPTION
package.json generates Universal build for both Intel and ARM64 macOS now.

Also suggesting a .gitignore for electron-based apps.